### PR TITLE
Fixed typo in /econ daily

### DIFF
--- a/src/InteractionEntrypoints/slashcommands/econ/daily.ts
+++ b/src/InteractionEntrypoints/slashcommands/econ/daily.ts
@@ -16,7 +16,7 @@ const albumRoles = roles.albums;
 command.setHandler(async (ctx) => {
     await ctx.reply({
         embeds: [
-            new MessageEmbed({ description: "Connecting to Daily Electronic Mesage Archive...", color: "#FF0000" })
+            new MessageEmbed({ description: "Connecting to Daily Electronic Message Archive...", color: "#FF0000" })
         ]
     });
 


### PR DESCRIPTION
/econ daily's first embed before generating the image and processing
said "mesage" instead of "message"