### PR TITLE
Switch /staff mute to use built-in timeout instead of muted role

### DIFF
--- a/src/Helpers/scheduler.ts
+++ b/src/Helpers/scheduler.ts
@@ -14,7 +14,6 @@ import {
 } from "date-fns";
 import { isBefore } from "date-fns/fp";
 import {
-    BaseMessageOptions,
     ChannelType,
     Client,
     Collection,
@@ -30,9 +29,9 @@ import SeedRandom from "seed-random";
 import { dropEmojiGuildId, guildID, roles } from "../Configuration/config";
 import secrets from "../Configuration/secrets";
 import { NUM_DAYS_FOR_CERTIFICATION, NUM_GOLDS_FOR_CERTIFICATION } from "../InteractionEntrypoints/contextmenus/gold";
+import { sendToStaff } from "../InteractionEntrypoints/slashcommands/apply/firebreathers";
 import F from "./funcs";
 import { prisma } from "./prisma-init";
-import { sendToStaff } from "../InteractionEntrypoints/slashcommands/apply/firebreathers";
 
 const safeCheck = async (p: Promise<unknown>) => {
     try {
@@ -52,7 +51,6 @@ export default async function (client: Client): Promise<void> {
     });
 
     async function every5Seconds() {
-        await safeCheck(checkMutes(guild));
         await safeCheck(checkReminders(guild));
         await safeCheck(checkMemberRoles(guild));
         await safeCheck(checkVCRoles(guild));
@@ -81,16 +79,6 @@ export default async function (client: Client): Promise<void> {
     every30Seconds();
     every60Seconds();
 }
-
-async function tryToDM(member: GuildMember, msg: BaseMessageOptions): Promise<void> {
-    try {
-        const dm = await member.createDM();
-        await dm.send(msg);
-    } catch (e) {
-        console.log(e, /UNABLE_TO_DM/);
-    }
-}
-
 
 async function checkReminders(guild: Guild): Promise<void> {
     const finishedReminders = await prisma.reminder.findMany({ where: { sendAt: { lte: new Date() } } });

--- a/src/Helpers/scheduler.ts
+++ b/src/Helpers/scheduler.ts
@@ -91,32 +91,6 @@ async function tryToDM(member: GuildMember, msg: BaseMessageOptions): Promise<vo
     }
 }
 
-async function checkMutes(guild: Guild): Promise<void> {
-    const finishedMutes = await prisma.mute.findMany({
-        where: { endsAt: { lte: new Date() }, finished: false }
-    });
-
-    for (const mute of finishedMutes) {
-        try {
-            const member = await guild.members.fetch(mute.mutedUserId.toSnowflake());
-
-            // Remove timeout, give back Banditos role
-            await member.roles.remove(roles.muted);
-            await member.roles.add(roles.banditos);
-
-            const embed = new EmbedBuilder({ description: "Your mute has ended." });
-            tryToDM(member, { embeds: [embed] });
-        } catch (e) {
-            console.log(e, mute.mutedUserId, /UNABLE_TO_UNMUTE/);
-        }
-    }
-
-    const fetchedIds = finishedMutes.map((r) => r.id);
-    await prisma.mute.updateMany({
-        where: { id: { in: fetchedIds } },
-        data: { finished: true }
-    });
-}
 
 async function checkReminders(guild: Guild): Promise<void> {
     const finishedReminders = await prisma.reminder.findMany({ where: { sendAt: { lte: new Date() } } });

--- a/src/InteractionEntrypoints/slashcommands/staff/mute.ts
+++ b/src/InteractionEntrypoints/slashcommands/staff/mute.ts
@@ -41,25 +41,7 @@ command.setHandler(async (ctx) => {
     const member = await ctx.member.guild.members.fetch(user);
     if (member.roles.cache.has(roles.staff)) throw new CommandError("Staff cannot be muted");
 
-    await member.roles.add(roles.muted);
-    await member.roles.remove(roles.banditos);
-
-    // Mark any current timeouts as finished (i.e. new timeout overrides any old ones)
-    await prisma.mute.updateMany({
-        where: { mutedUserId: member.id },
-        data: { finished: true }
-    });
-
-    // Add new timeout
-    await prisma.mute.create({
-        data: {
-            mutedUserId: member.id,
-            endsAt,
-            issuedByUserId: ctx.member.id,
-            channelId: ctx.channel.id,
-            reason
-        }
-    });
+    await member.timeout(durationMs, reason);
 
     const inMinutes = millisecondsToMinutes(durationMs);
     const timestamp = F.discordTimestamp(endsAt, "shortDateTime");

--- a/src/InteractionEntrypoints/slashcommands/staff/mute.ts
+++ b/src/InteractionEntrypoints/slashcommands/staff/mute.ts
@@ -1,12 +1,11 @@
-import { CommandError } from "../../../Configuration/definitions";
 import { addMilliseconds, millisecondsToMinutes } from "date-fns";
-import { EmbedBuilder, ApplicationCommandOptionType } from "discord.js";
+import { ApplicationCommandOptionType, EmbedBuilder } from "discord.js";
 import parseDuration from "parse-duration";
 import { roles } from "../../../Configuration/config";
-import F from "../../../Helpers/funcs";
-import { prisma } from "../../../Helpers/prisma-init";
-import { SlashCommand } from "../../../Structures/EntrypointSlashCommand";
+import { CommandError } from "../../../Configuration/definitions";
 import { MessageTools } from "../../../Helpers";
+import F from "../../../Helpers/funcs";
+import { SlashCommand } from "../../../Structures/EntrypointSlashCommand";
 
 const command = new SlashCommand(<const>{
     description: "Mutes a user",

--- a/src/InteractionEntrypoints/slashcommands/staff/unmute.ts
+++ b/src/InteractionEntrypoints/slashcommands/staff/unmute.ts
@@ -1,6 +1,4 @@
-import { EmbedBuilder, ApplicationCommandOptionType } from "discord.js";
-import { roles } from "../../../Configuration/config";
-import { prisma } from "../../../Helpers/prisma-init";
+import { ApplicationCommandOptionType, EmbedBuilder } from "discord.js";
 import { SlashCommand } from "../../../Structures/EntrypointSlashCommand";
 
 const command = new SlashCommand(<const>{

--- a/src/InteractionEntrypoints/slashcommands/staff/unmute.ts
+++ b/src/InteractionEntrypoints/slashcommands/staff/unmute.ts
@@ -15,14 +15,7 @@ command.setHandler(async (ctx) => {
     await ctx.deferReply();
 
     const member = await ctx.member.guild.members.fetch(user);
-    await member.roles.remove(roles.muted);
-    await member.roles.add(roles.banditos);
-
-    // Mark any current mutes as finished
-    await prisma.mute.updateMany({
-        where: { mutedUserId: member.id },
-        data: { finished: true }
-    });
+    await member.timeout(null);
 
     const embed = new EmbedBuilder().setDescription(`${member} has been unmuted!`);
     await ctx.send({ embeds: [embed] });


### PR DESCRIPTION
Timeout ensures no weird permission issues, and visually shows to staff members in chat.

Timeouts also will persist if they leave and rejoin, and discord handles the untimeout.

Having the command allows us to specify custom times, separate from what Discord gives us, and using timeout will remove the need for the bot to check and process unmutes

:)