### PR TITLE
Fix support thread permissions

### DIFF
--- a/src/InteractionEntrypoints/messageinteractions/ticket.ts
+++ b/src/InteractionEntrypoints/messageinteractions/ticket.ts
@@ -91,6 +91,7 @@ const genModalId = ticketInteraction.addInteractionListener("ticketSubmitModal",
         type: ChannelType.PrivateThread
     });
 
+    await thread.setInvitable(false);
     await thread.members.add(ctx.user.id);
     await thread.send({ content: `<@&${roles.staffSupport}>` });
 

--- a/src/InteractionEntrypoints/slashcommands/fm/_consts.ts
+++ b/src/InteractionEntrypoints/slashcommands/fm/_consts.ts
@@ -17,7 +17,8 @@ export class Album {
         this.artist = album.artist.name;
         this.name = album.name;
         this.playcount = +album.playCount;
-        this.image = album.image?.[album.image.length - 1].url
+
+        this.image = album.image?.at(-1)?.url || "http://orig14.deviantart.net/5162/f/2014/153/9/e/no_album_art__no_cover___placeholder_picture_by_cmdrobot-d7kpm65.jpg";
     }
 }
 


### PR DESCRIPTION
### Description
Currently, if a user mentions another user (@user), it will invite them to the
thread -- which is the exact opposite of what a user probably wants to do (i.e.
they're having issues with that user)

also fixes #76 