### PR TITLE
Handle max timeout duration

### DIFF
--- a/src/InteractionEntrypoints/slashcommands/staff/mute.ts
+++ b/src/InteractionEntrypoints/slashcommands/staff/mute.ts
@@ -34,6 +34,7 @@ command.setHandler(async (ctx) => {
 
     const durationMs = parseDuration(timeStr);
     if (!durationMs) throw new CommandError("Unable to parse duration.");
+    if (durationMs > 2419200000) throw new CommandError("You cannot mute longer than 28 days.")
 
     const endsAt = addMilliseconds(new Date(), durationMs);
 

--- a/src/InteractionEntrypoints/slashcommands/tools/break.ts
+++ b/src/InteractionEntrypoints/slashcommands/tools/break.ts
@@ -28,6 +28,7 @@ command.setHandler(async (ctx) => {
 
     const durationMs = parseDuration(timeStr);
     if (!durationMs) throw new CommandError("Unable to parse duration.");
+    if (durationMs > 2419200000) throw new CommandError("You cannot take a break longer than 28 days.")
 
     const endsAt = addMilliseconds(new Date(), durationMs);
 


### PR DESCRIPTION
Discord API specifies that the duration of a timeout cannot exceed 28 days
https://discord.com/developers/docs/resources/guild#modify-guild-member

If you attempt it currently, you get the generic "An unknown error occurred!"

Instead of trying to send it to the API and get an invalid request, check to make sure the duration does not exceed 28 days (2419200000 milliseconds), and throw a more descriptive error