### PR TITLE
Resupply fix - avoid negative number

### DIFF
--- a/src/InteractionEntrypoints/slashcommands/econ/resupply.ts
+++ b/src/InteractionEntrypoints/slashcommands/econ/resupply.ts
@@ -197,7 +197,7 @@ async function memberCaught(
 ): Promise<void> {
     const issuingBishop = F.capitalize(district.bishop) as BishopType;
     const emojiURL = `https://cdn.discordapp.com/emojis/${district.emoji}.png?v=1`;
-    const tokensRemaining = `${dailyBox.tokens - 1} token${dailyBox.tokens === 2 ? "" : "s"} remaining.`;
+    const tokensRemaining = `${dailyBox.tokens} token${dailyBox.tokens === 2 ? "" : "s"} remaining.`;
 
     const embed = new EmbedBuilder()
         .setColor(0xea523b)


### PR DESCRIPTION
Avoid the "You win nothing, -1 tokens remaining" text! https://i.imgur.com/FJ3mw1F.png

If the -1 had some other reasoning feel free to ignore but it's something that i've noticed